### PR TITLE
 fix dual app_main and read_file crash as file not exist

### DIFF
--- a/EFE2_Debug/storage/main/fat.c
+++ b/EFE2_Debug/storage/main/fat.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <errno.h>
 #include "esp_log.h"
 #include "esp_vfs.h"
 #include "esp_vfs_fat.h"
@@ -35,6 +36,12 @@ void read_file(char *path)
 {
     ESP_LOGI(TAG, "reading file %s", path);
     FILE *file = fopen(path, "r");
+    if (errno) {
+        ESP_LOGE(TAG, "%s fopen file %s error %s",
+                 __func__, path, strerror(errno));
+        errno = 0;
+        return;
+    }
     char buffer[100];
     fgets(buffer, 99, file);
     fclose(file);

--- a/EFE2_Debug/storage/main/spiffs.c
+++ b/EFE2_Debug/storage/main/spiffs.c
@@ -16,7 +16,7 @@
 
 static const char *TAG = "example";
 
-void app_main(void)
+void spiffs(void)
 {
     ESP_LOGI(TAG, "Initializing SPIFFS");
     


### PR DESCRIPTION
here are the issue seen without fixed
1. file_in_code(), nvs() and fat() not got executed as it runs app_main() in spiffs.c only.
2. after fix the above issue, software would crash in fat.c read_file as /store/flash-loaded.txt not exist, add error handling to prevent crash.

test result:

I (12) main_task: Calling app_main()
html = <!DOCTYPE html>
<html lang="en">

<head>

    <meta charset="UTF-8">

    <meta name="viewport" content="width=device-width, initial-scale=1.0">

    <meta http-equiv="X-UA-Compatible" content="ie=edge">

    <title>Document</title>

</head>

<body>
    This is the body
</body>

</html>

sample = a sample file

img size is 271887

I (52) NVS: Value read ok

I (54) NVS: Value read ok

I (54) NVS: read 148

I (1055) example: Initializing SPIFFS

I (1288) example: Partition size: total: 2824001, used: 502

I (1288) example: Opening file

I (1523) example: File written

I (1531) example: Renaming file

I (1647) example: Reading file

I (1648) example: Read from file: 'Hello World!'

I (1648) example: SPIFFS unmounted

I (1654) store: reading file /store/flash-loaded.txt

E (1655) store: read_file fopen file /store/flash-loaded.txt error Invalid argument

I (1663) store: Writing "Hello world!" to /store/text.txt

I (2011) store: reading file /store/text.txt

I (2014) store: file contains: Hello world!

I (2070) main_task: Returned from app_main()
